### PR TITLE
Upgrade `cheerio` and types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muninn",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "It parses the html and collects the requested data as desired.",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "ajv": "^8.1.0",
-    "cheerio": "1.0.0-rc.6"
+    "cheerio": "^1.0.0-rc.10"
   },
   "devDependencies": {
     "@types/mocha": "^8.2.2",

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,4 +1,4 @@
-import { Cheerio, CheerioAPI } from 'cheerio';
+import { Cheerio, CheerioAPI, Element } from 'cheerio';
 
 export type Selector = string | string[];
 
@@ -6,14 +6,14 @@ export type PreDefinedRegex = 'email' | 'url';
 export type RegexObject = { pattern: string; flags?: string };
 export type RegexConfig = PreDefinedRegex | RegexObject | RegExp;
 
-export type CustomFunction = (value: Cheerio<any>) => any;
-export type ConditionFunction = ($: Cheerio<Node>) => boolean;
-export type ConfigFunction = (el: Cheerio<any>) => {
+export type CustomFunction = (value: Cheerio<Element>) => any;
+export type ConditionFunction = ($: CheerioAPI | Cheerio<Element>) => boolean;
+export type ConfigFunction = (el: Cheerio<Element>) => {
   [key: string]: InputConfig;
 };
 export type ElementFilterFunction = (
   index: number,
-  element: Cheerio<any>,
+  element: Cheerio<Element> | Element,
   $: CheerioAPI
 ) => boolean;
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,4 +1,4 @@
-import * as cheerio from 'cheerio';
+import { Cheerio, CheerioAPI } from 'cheerio';
 
 export type Selector = string | string[];
 
@@ -7,14 +7,14 @@ export type RegexObject = { pattern: string; flags?: string };
 export type RegexConfig = PreDefinedRegex | RegexObject | RegExp;
 
 export type CustomFunction = (value: any) => any;
-export type ConditionFunction = ($: cheerio.Cheerio) => boolean;
-export type ConfigFunction = (el: cheerio.Cheerio) => {
+export type ConditionFunction = ($: Cheerio<Node>) => boolean;
+export type ConfigFunction = (el: any) => {
   [key: string]: InputConfig;
 };
 export type ElementFilterFunction = (
   index: number,
   element: any,
-  $: cheerio.Root
+  $: CheerioAPI
 ) => boolean;
 
 export type ConfigTypeValues = 'number' | 'float' | 'boolean' | 'array';

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -6,14 +6,14 @@ export type PreDefinedRegex = 'email' | 'url';
 export type RegexObject = { pattern: string; flags?: string };
 export type RegexConfig = PreDefinedRegex | RegexObject | RegExp;
 
-export type CustomFunction = (value: any) => any;
+export type CustomFunction = (value: Cheerio<any>) => any;
 export type ConditionFunction = ($: Cheerio<Node>) => boolean;
-export type ConfigFunction = (el: any) => {
+export type ConfigFunction = (el: Cheerio<any>) => {
   [key: string]: InputConfig;
 };
 export type ElementFilterFunction = (
   index: number,
-  element: any,
+  element: Cheerio<any>,
   $: CheerioAPI
 ) => boolean;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import parse from './parser/parse';
 import validateConfig from './config/validateConfig';
+import { RawConfig as Schema } from './config/types';
 
-export { parse, validateConfig };
+export { parse, validateConfig, Schema };

--- a/src/parser/getElement.ts
+++ b/src/parser/getElement.ts
@@ -1,11 +1,8 @@
-import * as cheerio from 'cheerio';
+import { Cheerio } from 'cheerio';
 import { ElementPassArg } from './types';
 import { Config } from '../config/types';
 
-function getElement(
-  { $, el }: ElementPassArg,
-  config: Config
-): cheerio.Cheerio {
+function getElement({ $, el }: ElementPassArg, config: Config): Cheerio<any> {
   if (!config) return $(el);
 
   const { selector, type } = config;

--- a/src/parser/getSchemaValue.ts
+++ b/src/parser/getSchemaValue.ts
@@ -4,7 +4,10 @@ import getConfig from '../config/getConfig';
 import getValue from './getValue';
 import { Config } from '../config/types';
 
-function getSchemaValue({ $, el }: ElementPassArg, config: Config): Object {
+function getSchemaValue(
+  { $, el }: ElementPassArg,
+  config: Config
+): Record<string, unknown> {
   const value = Object.keys(config).reduce((values, key) => {
     const currentRawConfig = getConfig({ $, el }, config[key]);
     values[key] = getValue({ $, el }, currentRawConfig);

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -1,9 +1,9 @@
-import { load, Root } from 'cheerio';
+import { load, CheerioAPI } from 'cheerio';
 import { InputConfig } from '../config/types';
 import getValue from './getValue';
 
 function parse(
-  data: string | Root,
+  data: string | CheerioAPI,
   config: InputConfig
 ): Record<string, unknown> {
   let $;

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -1,6 +1,6 @@
-import { Root, Cheerio } from 'cheerio';
+import { CheerioAPI } from 'cheerio';
 
 export type ElementPassArg = {
-  $?: Root;
-  el?: Cheerio | Element | string;
+  $?: CheerioAPI;
+  el?: any;
 };

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -1,6 +1,6 @@
-import { CheerioAPI } from 'cheerio';
+import { Cheerio, CheerioAPI, Element } from 'cheerio';
 
 export type ElementPassArg = {
   $?: CheerioAPI;
-  el?: any;
+  el?: Cheerio<Element> | string | Element;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -339,28 +339,29 @@ check-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
-cheerio-select@^1.3.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-1.4.0.tgz#3a16f21e37a2ef0f211d6d1aa4eff054bb22cdc9"
-  integrity sha512-sobR3Yqz27L553Qa7cK6rtJlMDbiKPdNywtR95Sj/YgfpLfy0u6CGJuaBKe5YE/vTc23SCRKxWSdlon/w6I/Ew==
+cheerio-select@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-1.6.0.tgz#489f36604112c722afa147dedd0d4609c09e1696"
+  integrity sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==
   dependencies:
-    css-select "^4.1.2"
-    css-what "^5.0.0"
+    css-select "^4.3.0"
+    css-what "^6.0.1"
     domelementtype "^2.2.0"
-    domhandler "^4.2.0"
-    domutils "^2.6.0"
+    domhandler "^4.3.1"
+    domutils "^2.8.0"
 
-cheerio@1.0.0-rc.6:
-  version "1.0.0-rc.6"
-  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.6.tgz#a5ae81ab483aeefa1280c325543c601145506240"
-  integrity sha512-hjx1XE1M/D5pAtMgvWwE21QClmAEeGHOIDfycgmndisdNgI6PE1cGRQkMGBcsbUbmEQyWu5PJLUcAOjtQS8DWw==
+cheerio@^1.0.0-rc.10:
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.10.tgz#2ba3dcdfcc26e7956fc1f440e61d51c643379f3e"
+  integrity sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==
   dependencies:
-    cheerio-select "^1.3.0"
-    dom-serializer "^1.3.1"
-    domhandler "^4.1.0"
+    cheerio-select "^1.5.0"
+    dom-serializer "^1.3.2"
+    domhandler "^4.2.0"
     htmlparser2 "^6.1.0"
     parse5 "^6.0.1"
     parse5-htmlparser2-tree-adapter "^6.0.1"
+    tslib "^2.2.0"
 
 chokidar@3.5.1:
   version "3.5.1"
@@ -429,21 +430,21 @@ cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-css-select@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.1.2.tgz#8b52b6714ed3a80d8221ec971c543f3b12653286"
-  integrity sha512-nu5ye2Hg/4ISq4XqdLY2bEatAcLIdt3OYGFc9Tm9n7VSlFBcfRv0gBNksHRgSdUDQGtN3XrZ94ztW+NfzkFSUw==
+css-select@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.3.0.tgz#db7129b2846662fd8628cfc496abb2b59e41529b"
+  integrity sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==
   dependencies:
     boolbase "^1.0.0"
-    css-what "^5.0.0"
-    domhandler "^4.2.0"
-    domutils "^2.6.0"
-    nth-check "^2.0.0"
+    css-what "^6.0.1"
+    domhandler "^4.3.1"
+    domutils "^2.8.0"
+    nth-check "^2.0.1"
 
-css-what@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.0.1.tgz#3efa820131f4669a8ac2408f9c32e7c7de9f4cad"
-  integrity sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==
+css-what@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
 
 debug@4.3.1, debug@^4.0.1, debug@^4.1.1, debug@^4.3.1:
   version "4.3.1"
@@ -493,10 +494,19 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-serializer@^1.0.1, dom-serializer@^1.3.1:
+dom-serializer@^1.0.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
   integrity sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.2.0"
+    entities "^2.0.0"
+
+dom-serializer@^1.3.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.4.1.tgz#de5d41b1aea290215dc45a6dae8adcf1d32e2d30"
+  integrity sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==
   dependencies:
     domelementtype "^2.0.1"
     domhandler "^4.2.0"
@@ -507,17 +517,33 @@ domelementtype@^2.0.1, domelementtype@^2.2.0:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
   integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
 
-domhandler@^4.0.0, domhandler@^4.1.0, domhandler@^4.2.0:
+domhandler@^4.0.0, domhandler@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.2.0.tgz#f9768a5f034be60a89a27c2e4d0f74eba0d8b059"
   integrity sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==
   dependencies:
     domelementtype "^2.2.0"
 
-domutils@^2.5.2, domutils@^2.6.0:
+domhandler@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.1.tgz#8d792033416f59d68bc03a5aa7b018c1ca89279c"
+  integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
+  dependencies:
+    domelementtype "^2.2.0"
+
+domutils@^2.5.2:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.6.0.tgz#2e15c04185d43fb16ae7057cb76433c6edb938b7"
   integrity sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
+
+domutils@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
+  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
   dependencies:
     dom-serializer "^1.0.1"
     domelementtype "^2.2.0"
@@ -1128,10 +1154,10 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-nth-check@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.0.tgz#1bb4f6dac70072fc313e8c9cd1417b5074c0a125"
-  integrity sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==
+nth-check@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.1.tgz#2efe162f5c3da06a28959fbd3db75dbeea9f0fc2"
+  integrity sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==
   dependencies:
     boolbase "^1.0.0"
 
@@ -1462,6 +1488,11 @@ tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.2.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
The schema type can now be imported.
```js
import { Schema } from "muninn";
```

Cheerio upgrade from `^1.0.0-rc.6` to `^1.0.0-rc.10` 