### PR TITLE
implemented "ignore existence checks" feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muninn",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "It parses the html and collects the requested data as desired.",
   "main": "build/index.js",
   "scripts": {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -40,6 +40,7 @@ export interface RawConfig {
         [key: string]: InputConfig;
       };
   ignoreIntersectingElements?: 'ignore-kids' | 'ignore-parents';
+  ignoreExistenceChecks?: boolean;
 }
 
 export type InputConfig = ConfigFunction | RawConfig | Selector;

--- a/src/parser/getValue.spec.ts
+++ b/src/parser/getValue.spec.ts
@@ -280,3 +280,47 @@ describe('getValue Tests', () => {
     expect(['First Child']).to.deep.equal(value);
   });
 });
+
+describe('ignoreExistenceChecks', () => {
+  const el = $('.parent');
+
+  it('ReturnNull', () => {
+    const config: RawConfig = {
+      selector: '.non-existent',
+      ignoreExistenceChecks: false,
+      schema: {
+        selector: '.non-existent'
+      }
+    };
+    const value = getValue({ $, el }, config);
+
+    expect(null).to.deep.equal(value);
+  });
+
+  it('ReturEmptyObject', () => {
+    const config: RawConfig = {
+      selector: '.non-existent',
+      ignoreExistenceChecks: true,
+      schema: {}
+    };
+    const value = getValue({ $, el }, config);
+
+    expect({}).to.deep.equal(value);
+  });
+
+  it('ReturObjectWithNullValues', () => {
+    const config: RawConfig = {
+      selector: '.non-existent',
+      ignoreExistenceChecks: true,
+      schema: {
+        willBeNull: '#fake-selector'
+      }
+    };
+    const value = getValue({ $, el }, config);
+    const expected = {
+      willBeNull: null
+    };
+
+    expect(value).to.deep.equal(expected);
+  });
+});

--- a/src/parser/getValue.ts
+++ b/src/parser/getValue.ts
@@ -10,11 +10,12 @@ import getArrayValue from './getArrayValue';
 function getValue({ $, el }: ElementPassArg, inputConfig: InputConfig) {
   const config = getConfig({ $, el }, inputConfig);
   const element = getElement({ $, el }, config);
-  const { type, selector, condition, exist, ...rest } = config;
+  const { type, condition, exist, ...rest } = config;
   const { schema } = rest;
+  const elemExists = element.length > 0;
 
   if (exist) {
-    return $(selector).length > 0;
+    return elemExists;
   }
 
   if (condition && !condition($(el))) {
@@ -25,9 +26,17 @@ function getValue({ $, el }: ElementPassArg, inputConfig: InputConfig) {
     if (config?.methods?.includes('size')) {
       return $(element).length;
     }
+
     return getArrayValue({ $, el: element }, rest);
   } else if (schema) {
     const currentSchema = getConfig({ $, el }, schema);
+
+    if (!elemExists) {
+      if (!(config.ignoreExistenceChecks === true)) {
+        return rest.initial ?? null;
+      }
+    }
+
     return getSchemaValue({ $, el: element }, currentSchema);
   } else {
     return getSimpleValue({ $, el: element }, rest);


### PR DESCRIPTION
Sometimes we may want to build an empty object if the object's selector doesn't exist. The new `ignoreExistenceChecks` option allows users to force `muninn` to build an object in these cases.