### PR TITLE
allow multiple input configs/schemas to be provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+v0.11.0:
+  * The `InputConfig` removed.
+  * The `Config` `interface` converted to a `type` and replaced the `InputConfig`.
+  * `Selector` can only be `string` (was `string | string[]`)
+  * `transform` function takes `Value<Initial>` as argument, instead of `any`.
+  * `ConfigFunction` renamed to `SchemaGenerator`
+  * `RawConfig.schema`'s type is set to `SchemaGenerator | Schema`
+  * `getSelector` renamed to `parseSelector`
+
 v0.9.1:
   * Ignored `null` values returned from `cheerio.html()`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muninn",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "It parses the html and collects the requested data as desired.",
   "main": "build/index.js",
   "scripts": {

--- a/src/config/applyMethods.ts
+++ b/src/config/applyMethods.ts
@@ -1,0 +1,25 @@
+import { RawConfig } from './types';
+
+export function applyMethods<Initial = unknown>(
+  conf: RawConfig<Initial>
+): typeof conf {
+  const { methods } = conf;
+
+  if (!methods) {
+    return;
+  }
+
+  const type = methods.includes('array') ? 'array' : conf.type;
+  const html = methods.includes('html') ? true : conf.html;
+  const exist = methods.includes('exist') ? true : conf.exist;
+  let trim = methods.includes('trim') ? true : conf.trim;
+
+  trim = methods.includes('non-trim') ? false : conf.trim;
+
+  if (type) conf.type = type;
+  if (html) conf.html = html;
+  if (exist) conf.exist = exist;
+  if (typeof trim === 'boolean') conf.trim = trim;
+
+  return conf;
+}

--- a/src/config/getConfig.spec.ts
+++ b/src/config/getConfig.spec.ts
@@ -1,13 +1,14 @@
 import { expect } from 'chai';
 
 import getConfig from './getConfig';
-import { RawConfig } from './types';
 
 describe('getConfig Tests', () => {
   it('Case 1: string config: @ attr', () => {
     const config = { selector: '@ href' };
     const value = getConfig({}, config);
-    expect({ attr: 'href' }).to.deep.equal(value);
+    const expected = { selector: '', attr: 'href' };
+
+    expect(value).to.deep.equal(expected);
   });
 
   it('Case 2: string config: selector', () => {
@@ -74,17 +75,17 @@ describe('getConfig Tests', () => {
 
   it('Case 10: object config: () => ({ selector @ attr | html* })', () => {
     const config = {
-      selector: '',
-      schema: () => ({ selector: 'a.link @ href | html' })
+      selector: 'a.link @ href | html'
     };
     const value = getConfig({}, config);
-
-    expect({
+    const expected = {
       selector: 'a.link',
       attr: 'href',
       html: true,
       methods: ['html']
-    }).to.deep.equal(value);
+    };
+
+    expect(value).to.deep.equal(expected);
   });
 
   it('Case 11: object config: () => ({ selector | exist })', () => {

--- a/src/config/getConfig.spec.ts
+++ b/src/config/getConfig.spec.ts
@@ -30,7 +30,9 @@ describe('getConfig Tests', () => {
   it('Case 4:  array config: [selector, selector]', () => {
     const config = ['a.link', 'b.link'];
     const value = getConfig({}, config);
-    expect({ selector: 'a.link, b.link' }).to.deep.equal(value);
+    const expected = [{ selector: 'a.link' }, { selector: 'b.link' }];
+
+    expect(value).to.deep.equal(expected);
   });
 
   it('Case 5: object config: { selector, attr }', () => {

--- a/src/config/getConfig.spec.ts
+++ b/src/config/getConfig.spec.ts
@@ -1,38 +1,31 @@
 import { expect } from 'chai';
 
 import getConfig from './getConfig';
+import { RawConfig } from './types';
 
 describe('getConfig Tests', () => {
   it('Case 1: string config: @ attr', () => {
-    const config = '@ href';
+    const config = { selector: '@ href' };
     const value = getConfig({}, config);
     expect({ attr: 'href' }).to.deep.equal(value);
   });
 
   it('Case 2: string config: selector', () => {
-    const config = 'a.link';
+    const config = { selector: 'a.link' };
     const value = getConfig({}, config);
     expect({ selector: 'a.link' }).to.deep.equal(value);
   });
 
   it('Case 3: string config: selector @ attr', () => {
-    const config = 'a.link @ href';
+    const config = { selector: 'a.link @ href' };
     const value = getConfig({}, config);
     expect({ selector: 'a.link', attr: 'href' }).to.deep.equal(value);
   });
 
   it('Case 4:  array config: [selector, selector]', () => {
-    const config = 'a.link, b.link';
+    const config = { selector: 'a.link, b.link' };
     const value = getConfig({}, config);
     expect({ selector: 'a.link, b.link' }).to.deep.equal(value);
-  });
-
-  it('Case 4:  array config: [selector, selector]', () => {
-    const config = ['a.link', 'b.link'];
-    const value = getConfig({}, config);
-    const expected = [{ selector: 'a.link' }, { selector: 'b.link' }];
-
-    expect(value).to.deep.equal(expected);
   });
 
   it('Case 5: object config: { selector, attr }', () => {
@@ -80,8 +73,12 @@ describe('getConfig Tests', () => {
   });
 
   it('Case 10: object config: () => ({ selector @ attr | html* })', () => {
-    const config = () => ({ selector: 'a.link @ href | html' });
+    const config = {
+      selector: '',
+      schema: () => ({ selector: 'a.link @ href | html' })
+    };
     const value = getConfig({}, config);
+
     expect({
       selector: 'a.link',
       attr: 'href',

--- a/src/config/getConfig.ts
+++ b/src/config/getConfig.ts
@@ -4,15 +4,19 @@ import { Config, InputConfig, RawConfig } from './types';
 
 function getConfig(
   { $, el }: ElementPassArg,
-  inputConfig: InputConfig
-): Config {
+  inputConfig?: InputConfig
+): Config | Config[] {
   if (!inputConfig) return {};
 
   if (typeof inputConfig === 'function') {
     inputConfig = <RawConfig>inputConfig($ && el ? $(el) : null);
   }
 
-  if (typeof inputConfig === 'string' || Array.isArray(inputConfig)) {
+  if (Array.isArray(inputConfig)) {
+    return inputConfig.map((conf) => getConfig({ $, el }, conf));
+  }
+
+  if (typeof inputConfig === 'string') {
     inputConfig = parseSelector(inputConfig);
   } else if (inputConfig?.selector) {
     const config = <Config>inputConfig;

--- a/src/config/getConfig.ts
+++ b/src/config/getConfig.ts
@@ -1,46 +1,54 @@
 import parseSelector from './getSelector';
 import { ElementPassArg } from '../parser/types';
-import { Config, InputConfig, RawConfig } from './types';
+import { Config, RawConfig } from './types';
 
-function getConfig(
+function getConfig<Initial = unknown>(
   { $, el }: ElementPassArg,
-  inputConfig?: InputConfig
-): Config | Config[] {
-  if (!inputConfig) return {};
-
-  if (typeof inputConfig === 'function') {
-    inputConfig = <RawConfig>inputConfig($ && el ? $(el) : null);
+  conf?: RawConfig<Initial>
+): RawConfig<Initial>;
+function getConfig<Initial = unknown>(
+  { $, el }: ElementPassArg,
+  conf?: Config<Initial>
+): Config<Initial> | Config<Initial>[] {
+  if (!conf) {
+    return { selector: '' };
   }
 
-  if (Array.isArray(inputConfig)) {
-    return inputConfig.map((conf) => getConfig({ $, el }, conf));
-  }
+  if (typeof conf === 'function') {
+    const schema = conf($ && el ? $(el) : null);
 
-  if (typeof inputConfig === 'string') {
-    inputConfig = parseSelector(inputConfig);
-  } else if (inputConfig?.selector) {
-    const config = <Config>inputConfig;
-    inputConfig = {
-      ...config,
-      ...parseSelector(config.selector)
+    conf = {
+      selector: '',
+      schema
     };
   }
 
-  const { methods } = inputConfig;
-  const type = methods?.includes('array') ? 'array' : inputConfig.type;
-  const html = methods?.includes('html') ? true : inputConfig.html;
-  const exist = methods?.includes('exist') ? true : inputConfig.exist;
-  let trim = methods?.includes('trim') ? true : inputConfig.trim;
-  trim = methods?.includes('non-trim') ? false : inputConfig.trim;
+  if (Array.isArray(conf)) {
+    return conf.map((conf) => getConfig({ $, el }, conf));
+  }
 
-  if (type) inputConfig.type = type;
-  if (html) inputConfig.html = html;
-  if (exist) inputConfig.exist = exist;
-  if (typeof trim === 'boolean') inputConfig.trim = trim;
+  if (typeof conf === 'string') {
+    conf = parseSelector(conf);
+  } else if (conf?.selector) {
+    conf = {
+      ...conf,
+      ...parseSelector(conf.selector)
+    };
+  }
 
-  const config = <Config>inputConfig;
+  const { methods } = conf;
+  const type = methods?.includes('array') ? 'array' : conf.type;
+  const html = methods?.includes('html') ? true : conf.html;
+  const exist = methods?.includes('exist') ? true : conf.exist;
+  let trim = methods?.includes('trim') ? true : conf.trim;
+  trim = methods?.includes('non-trim') ? false : conf.trim;
 
-  return config;
+  if (type) conf.type = type;
+  if (html) conf.html = html;
+  if (exist) conf.exist = exist;
+  if (typeof trim === 'boolean') conf.trim = trim;
+
+  return conf;
 }
 
 export default getConfig;

--- a/src/config/getConfig.ts
+++ b/src/config/getConfig.ts
@@ -1,6 +1,7 @@
-import parseSelector from './getSelector';
+import parseSelector from './parseSelector';
 import { ElementPassArg } from '../parser/types';
 import { Config, RawConfig } from './types';
+import { applyMethods } from './applyMethods';
 
 function getConfig<Initial = unknown>(
   { $, el }: ElementPassArg,
@@ -36,17 +37,7 @@ function getConfig<Initial = unknown>(
     };
   }
 
-  const { methods } = conf;
-  const type = methods?.includes('array') ? 'array' : conf.type;
-  const html = methods?.includes('html') ? true : conf.html;
-  const exist = methods?.includes('exist') ? true : conf.exist;
-  let trim = methods?.includes('trim') ? true : conf.trim;
-  trim = methods?.includes('non-trim') ? false : conf.trim;
-
-  if (type) conf.type = type;
-  if (html) conf.html = html;
-  if (exist) conf.exist = exist;
-  if (typeof trim === 'boolean') conf.trim = trim;
+  applyMethods(conf);
 
   return conf;
 }

--- a/src/config/getSelector.spec.ts
+++ b/src/config/getSelector.spec.ts
@@ -36,7 +36,7 @@ describe('getSelector Tests', () => {
   });
 
   it('Case 5: [selector, selector]', () => {
-    const selector = ['a.link', 'b.link'];
+    const selector = 'a.link, b.link';
     const value = getSelector(selector);
     expect({
       selector: 'a.link, b.link'

--- a/src/config/getSelector.ts
+++ b/src/config/getSelector.ts
@@ -1,7 +1,9 @@
-import { Selector, Config, RawConfig } from './types';
+import { Selector, RawConfig } from './types';
 
-const parseSelector = (selector: Selector): RawConfig => {
-  const config: Config = {};
+function parseSelector<Initial = unknown>(
+  selector: Selector
+): RawConfig<Initial> {
+  const config: RawConfig<Initial> = { selector };
 
   let $selector, methods, attr;
 
@@ -37,6 +39,6 @@ const parseSelector = (selector: Selector): RawConfig => {
   }
 
   return config;
-};
+}
 
 export default parseSelector;

--- a/src/config/getSelector.ts
+++ b/src/config/getSelector.ts
@@ -5,10 +5,6 @@ const parseSelector = (selector: Selector): RawConfig => {
 
   let $selector, methods, attr;
 
-  if (Array.isArray(selector)) {
-    return { selector: selector.join(', ') };
-  }
-
   if (typeof selector !== 'string') {
     return selector;
   }

--- a/src/config/parseSelector.spec.ts
+++ b/src/config/parseSelector.spec.ts
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 
-import getSelector from './parseSelector';
+import parseSelector from './parseSelector';
 
-describe('getSelector Tests', () => {
+describe('parseSelector Tests', () => {
   it('Case 1: @ attr', () => {
     const selector = '@ href';
-    const value = getSelector(selector);
+    const value = parseSelector(selector);
     const expected = { selector: '', attr: 'href' };
 
     expect(value).to.deep.equal(expected);
@@ -13,7 +13,7 @@ describe('getSelector Tests', () => {
 
   it('Case 2: selector @ attr', () => {
     const selector = 'a.link @ href';
-    const value = getSelector(selector);
+    const value = parseSelector(selector);
     const expected = { selector: 'a.link', attr: 'href' };
 
     expect(value).to.deep.equal(expected);
@@ -21,7 +21,7 @@ describe('getSelector Tests', () => {
 
   it('Case 3: selector @ attr | method', () => {
     const selector = 'a.link @ href | url';
-    const value = getSelector(selector);
+    const value = parseSelector(selector);
     expect({
       selector: 'a.link',
       attr: 'href',
@@ -31,7 +31,7 @@ describe('getSelector Tests', () => {
 
   it('Case 4: selector @ attr | method | method', () => {
     const selector = 'a.link @ href | url | uppercase';
-    const value = getSelector(selector);
+    const value = parseSelector(selector);
     expect({
       selector: 'a.link',
       attr: 'href',
@@ -41,7 +41,7 @@ describe('getSelector Tests', () => {
 
   it('Case 5: [selector, selector]', () => {
     const selector = 'a.link, b.link';
-    const value = getSelector(selector);
+    const value = parseSelector(selector);
     expect({
       selector: 'a.link, b.link'
     }).to.deep.equal(value);
@@ -49,7 +49,7 @@ describe('getSelector Tests', () => {
 
   it('Case 6: selector, array*', () => {
     const selector = '.parent div | array';
-    const value = getSelector(selector);
+    const value = parseSelector(selector);
     expect({
       selector: '.parent div',
       type: 'array',

--- a/src/config/parseSelector.spec.ts
+++ b/src/config/parseSelector.spec.ts
@@ -1,18 +1,22 @@
 import { expect } from 'chai';
 
-import getSelector from './getSelector';
+import getSelector from './parseSelector';
 
 describe('getSelector Tests', () => {
   it('Case 1: @ attr', () => {
     const selector = '@ href';
     const value = getSelector(selector);
-    expect({ attr: 'href' }).to.deep.equal(value);
+    const expected = { selector: '', attr: 'href' };
+
+    expect(value).to.deep.equal(expected);
   });
 
   it('Case 2: selector @ attr', () => {
     const selector = 'a.link @ href';
     const value = getSelector(selector);
-    expect({ selector: 'a.link', attr: 'href' }).to.deep.equal(value);
+    const expected = { selector: 'a.link', attr: 'href' };
+
+    expect(value).to.deep.equal(expected);
   });
 
   it('Case 3: selector @ attr | method', () => {

--- a/src/config/parseSelector.ts
+++ b/src/config/parseSelector.ts
@@ -3,24 +3,25 @@ import { Selector, RawConfig } from './types';
 function parseSelector<Initial = unknown>(
   selector: Selector
 ): RawConfig<Initial> {
-  const config: RawConfig<Initial> = { selector };
+  const config: RawConfig<Initial> = { selector: '' };
 
-  let $selector, methods, attr;
+  let $selector: string, methods: string[], attr: string;
 
   if (typeof selector !== 'string') {
     return selector;
   }
 
-  if (selector?.includes('|')) {
+  if (selector.includes('|')) {
     [$selector, ...methods] = selector.split('|').map((key) => key.trim());
-    methods?.map((p) => p.trim());
+
+    methods = methods.map((p: string) => p.trim());
   }
 
   if (!$selector) {
     $selector = selector;
   }
 
-  if ($selector?.includes('@')) {
+  if ($selector.includes('@')) {
     [$selector, attr] = $selector.split('@').map((key) => key.trim());
   }
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,4 +1,5 @@
 import { Cheerio, CheerioAPI, Element } from 'cheerio';
+import { Value } from '../parser/value';
 
 export type Selector = string;
 
@@ -6,11 +7,16 @@ export type PreDefinedRegex = 'email' | 'url';
 export type RegexObject = { pattern: string; flags?: string };
 export type RegexConfig = PreDefinedRegex | RegexObject | RegExp;
 
-export type TransformFunction = (value: any) => any;
+export type TransformFunction<Initial = unknown> = (
+  value: Value<Initial>
+) => Value<Initial>;
 export type ConditionFunction = ($: CheerioAPI | Cheerio<Element>) => boolean;
-export type ConfigFunction = (el: Cheerio<Element>) => {
-  [key: string]: InputConfig;
-};
+export interface Schema<Initial = unknown> {
+  [key: string]: Config<Initial>;
+}
+export type SchemaGenerator<Initial = unknown> = (
+  el: Cheerio<Element>
+) => Schema<Initial>;
 export type ElementFilterFunction = (
   index: number,
   element: Cheerio<Element> | Element,
@@ -19,8 +25,8 @@ export type ElementFilterFunction = (
 
 export type ConfigTypeValues = 'number' | 'float' | 'boolean' | 'array';
 
-export interface RawConfig {
-  selector?: Selector;
+export interface RawConfig<Initial = unknown> {
+  selector: Selector;
   html?: boolean;
   attr?: string;
   type?: ConfigTypeValues;
@@ -28,27 +34,19 @@ export interface RawConfig {
   exist?: boolean;
   rootScope?: boolean;
   elementFilter?: ElementFilterFunction;
-  initial?: any;
+  initial?: Initial;
   fill?: any;
   methods?: string[];
   regex?: RegexConfig;
-  transform?: TransformFunction;
+  transform?: TransformFunction<Initial>;
   condition?: ConditionFunction;
-  schema?:
-    | ConfigFunction
-    | {
-        [key: string]: InputConfig;
-      };
+  schema?: SchemaGenerator<Initial> | Schema<Initial>;
   ignoreIntersectingElements?: 'ignore-kids' | 'ignore-parents';
   ignoreExistenceChecks?: boolean;
 }
 
-export type InputConfig = ConfigFunction | RawConfig | RawConfig[] | Selector;
-
-export interface Config extends RawConfig {
-  selector?: string;
-}
-
-export type Schema = {
-  [key: string]: InputConfig;
-};
+export type Config<Initial = unknown> =
+  | SchemaGenerator<Initial>
+  | RawConfig<Initial>
+  | RawConfig<Initial>[]
+  | Selector;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,6 +1,6 @@
 import { Cheerio, CheerioAPI, Element } from 'cheerio';
 
-export type Selector = string | string[];
+export type Selector = string;
 
 export type PreDefinedRegex = 'email' | 'url';
 export type RegexObject = { pattern: string; flags?: string };
@@ -43,7 +43,7 @@ export interface RawConfig {
   ignoreExistenceChecks?: boolean;
 }
 
-export type InputConfig = ConfigFunction | RawConfig | Selector;
+export type InputConfig = ConfigFunction | RawConfig | RawConfig[] | Selector;
 
 export interface Config extends RawConfig {
   selector?: string;

--- a/src/parser/getArrayValue.spec.ts
+++ b/src/parser/getArrayValue.spec.ts
@@ -21,7 +21,7 @@ describe('getArrayValue', () => {
   });
 
   it('withoutIgnore', () => {
-    const result = getArrayValue({ $, el: '#root div' }, {});
+    const result = getArrayValue({ $, el: '#root div' }, { selector: '' });
     const expected = [
       'First Child Second Child',
       'Second Child',
@@ -34,7 +34,7 @@ describe('getArrayValue', () => {
   it('withIgnoreKids', () => {
     const result = getArrayValue(
       { $, el: '#root div' },
-      { ignoreIntersectingElements: 'ignore-kids' }
+      { selector: '', ignoreIntersectingElements: 'ignore-kids' }
     );
     const expected = ['First Child Second Child', 'Third Child'];
 
@@ -44,7 +44,7 @@ describe('getArrayValue', () => {
   it('withIgnoreParents', () => {
     const result = getArrayValue(
       { $, el: '#root div' },
-      { ignoreIntersectingElements: 'ignore-parents' }
+      { selector: '', ignoreIntersectingElements: 'ignore-parents' }
     );
     const expected = ['Second Child', 'Third Child'];
 

--- a/src/parser/getArrayValue.ts
+++ b/src/parser/getArrayValue.ts
@@ -1,18 +1,25 @@
 import { Cheerio, CheerioAPI, Element } from 'cheerio';
-import { Config, RawConfig } from '../config/types';
+import { RawConfig } from '../config/types';
 import getValue from './getValue';
 import { ElementPassArg } from './types';
 
-function getArrayValue(
+function getArrayValue<Initial = unknown>(
   { $, el: element }: ElementPassArg,
-  config: Config
+  config: RawConfig<Initial>
 ): any[] {
   const values = [];
   let elems = $(element);
 
   function eachFunction(index, el) {
     const { selector, type, ...rest } = config;
-    const value = getValue({ $, el: $(el) }, rest);
+    const value = getValue(
+      { $, el: $(el) },
+      {
+        selector: '',
+        ...rest
+      }
+    );
+
     values.push(value);
   }
 

--- a/src/parser/getElement.ts
+++ b/src/parser/getElement.ts
@@ -1,8 +1,11 @@
-import { Cheerio } from 'cheerio';
+import { Cheerio, Element } from 'cheerio';
 import { ElementPassArg } from './types';
-import { Config } from '../config/types';
+import { RawConfig } from '../config/types';
 
-function getElement({ $, el }: ElementPassArg, config: Config): Cheerio<any> {
+function getElement<Initial = unknown>(
+  { $, el }: ElementPassArg,
+  config: RawConfig<Initial>
+): Cheerio<Element> {
   if (!config) return $(el);
 
   const { selector, rootScope, type } = config;

--- a/src/parser/getRawConfig.ts
+++ b/src/parser/getRawConfig.ts
@@ -1,0 +1,23 @@
+import parseSelector from '../config/getSelector';
+import { Config, RawConfig } from '../config/types';
+
+export function getRawConfig<Initial = unknown>(
+  conf: Config<Initial>
+): RawConfig<Initial> | RawConfig<Initial>[] {
+  if (typeof conf === 'string') {
+    return parseSelector(conf);
+  }
+
+  if (typeof conf === 'function') {
+    return {
+      selector: '',
+      schema: conf
+    };
+  }
+
+  if (Array.isArray(conf)) {
+    return conf.map((c) => getRawConfig(c) as RawConfig<Initial>);
+  }
+
+  return conf;
+}

--- a/src/parser/getRawConfig.ts
+++ b/src/parser/getRawConfig.ts
@@ -1,4 +1,4 @@
-import parseSelector from '../config/getSelector';
+import parseSelector from '../config/parseSelector';
 import { Config, RawConfig } from '../config/types';
 
 export function getRawConfig<Initial = unknown>(
@@ -17,6 +17,13 @@ export function getRawConfig<Initial = unknown>(
 
   if (Array.isArray(conf)) {
     return conf.map((c) => getRawConfig(c) as RawConfig<Initial>);
+  }
+
+  if (conf.selector !== '') {
+    return {
+      ...conf,
+      ...parseSelector(conf.selector)
+    };
   }
 
   return conf;

--- a/src/parser/getSchemaValue.ts
+++ b/src/parser/getSchemaValue.ts
@@ -1,14 +1,38 @@
 import getConfig from '../config/getConfig';
-import { Config } from '../config/types';
+import { Schema, SchemaGenerator } from '../config/types';
+import { getRawConfig } from './getRawConfig';
 import getValue from './getValue';
 import { ElementPassArg } from './types';
 
-function getSchemaValue(
+function getSchemaValue<Initial = unknown>(
   { $, el }: ElementPassArg,
-  config: Config
-): Record<string, unknown> {
+  config: Schema<Initial>
+): Record<keyof Exclude<typeof config, SchemaGenerator>['schema'], unknown> {
   const value = Object.keys(config).reduce((values, key) => {
-    const currentRawConfig = getConfig({ $, el }, config[key]);
+    const conf = config[key];
+    const rawConf = getRawConfig(conf);
+
+    if (Array.isArray(rawConf)) {
+      for (const conf of rawConf) {
+        let schema = conf.schema;
+
+        if (typeof schema === 'function') {
+          schema = schema($ && el ? $(el) : null);
+        }
+
+        const val = getSchemaValue<Initial>({ $, el }, schema);
+
+        if (val !== null && val !== undefined) {
+          values[key] = val;
+          break;
+        }
+      }
+
+      return values;
+    }
+
+    const currentRawConfig = getConfig({ $, el }, rawConf);
+
     values[key] = getValue({ $, el }, currentRawConfig);
 
     return values;

--- a/src/parser/getSimpleValue.ts
+++ b/src/parser/getSimpleValue.ts
@@ -1,5 +1,5 @@
 import { RawConfig } from '../config/types';
-import parseSelector from '../config/getSelector';
+import parseSelector from '../config/parseSelector';
 import transformValue from './transformValue';
 import { ElementPassArg } from './types';
 import { Value } from './value';
@@ -12,15 +12,7 @@ function getSimpleValue<Initial = unknown>(
     config = parseSelector(config);
   }
 
-  const { html, attr, initial, fill } = config;
-
-  if (fill) {
-    if (typeof fill === 'function') {
-      return fill();
-    }
-
-    return fill;
-  }
+  const { html, attr, initial } = config;
 
   const element = $(el);
   let value: string | Initial;
@@ -40,7 +32,7 @@ function getSimpleValue<Initial = unknown>(
   if (
     value === null ||
     value === undefined ||
-    (value === '' && typeof initial === 'string' && initial !== '')
+    (value === '' && !(typeof initial === 'string' && initial === ''))
   ) {
     return null;
   }

--- a/src/parser/getSimpleValue.ts
+++ b/src/parser/getSimpleValue.ts
@@ -1,4 +1,4 @@
-import { Config } from '../config/types';
+import { RawConfig } from '../config/types';
 import parseSelector from '../config/getSelector';
 import transformValue from './transformValue';
 import { ElementPassArg } from './types';
@@ -6,27 +6,8 @@ import { Value } from './value';
 
 function getSimpleValue<Initial = unknown>(
   { $, el }: ElementPassArg,
-  config: Config<Initial>
+  config: RawConfig<Initial>
 ): Value<Initial> {
-  if (typeof config === 'function') {
-    config = {
-      selector: '',
-      schema: config($(el))
-    };
-  }
-
-  if (Array.isArray(config)) {
-    for (const c of config) {
-      const value = getSimpleValue({ $, el }, c);
-
-      if (value !== null && value !== undefined) {
-        return value;
-      }
-    }
-
-    return null;
-  }
-
   if (typeof config === 'string') {
     config = parseSelector(config);
   }

--- a/src/parser/getValue.spec.ts
+++ b/src/parser/getValue.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
-import { InputConfig, RawConfig } from '../config/types';
+import { Config, RawConfig } from '../config/types';
 import getValue from './getValue';
 
 const BLOCK_HTML = `
@@ -325,7 +325,10 @@ describe('ignoreExistenceChecks', () => {
 
 describe('MultipleSchemas', () => {
   it('GetContentsOfTheFirstMatchingSelector', () => {
-    const conf: InputConfig = ['#non-existent', '.first-child'];
+    const conf: Config = [
+      { selector: '#non-existent' },
+      { selector: '.first-child' }
+    ];
     const el = $('.parent:first');
     const val = getValue({ $, el }, conf);
     const expected = $('.first-child:first').text();

--- a/src/parser/getValue.spec.ts
+++ b/src/parser/getValue.spec.ts
@@ -254,14 +254,14 @@ describe('getValue Tests', () => {
   it('Case 16: { selector, exist }', () => {
     const el = $('.parent');
     const selector = '.empty-child | exist';
-    const value = getValue({ $, el }, selector);
+    const value = getValue({ $, el }, { selector });
     expect(true).to.deep.equal(value);
   });
 
   it('Case 17: { selector, non-exist }', () => {
     const el = $('.parent');
     const selector = '.non-exist-child | exist';
-    const value = getValue({ $, el }, selector);
+    const value = getValue({ $, el }, { selector });
     expect(false).to.deep.equal(value);
   });
 

--- a/src/parser/getValue.spec.ts
+++ b/src/parser/getValue.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
+import parseSelector from '../config/parseSelector';
 import { Config, RawConfig } from '../config/types';
 import getValue from './getValue';
 
@@ -203,11 +204,12 @@ describe('getValue Tests', () => {
   });
 
   it('Case 13: { selector, fill() }', () => {
-    const config = {
+    const config: RawConfig = {
       selector: 'a.href',
       fill: () => 'link censored'
     };
     const value = getValue({ $ }, config);
+
     expect('link censored').to.deep.equal(value);
   });
 
@@ -254,15 +256,17 @@ describe('getValue Tests', () => {
   it('Case 16: { selector, exist }', () => {
     const el = $('.parent');
     const selector = '.empty-child | exist';
-    const value = getValue({ $, el }, { selector });
+    const value = getValue({ $, el }, parseSelector(selector));
+
     expect(true).to.deep.equal(value);
   });
 
   it('Case 17: { selector, non-exist }', () => {
     const el = $('.parent');
-    const selector = '.non-exist-child | exist';
-    const value = getValue({ $, el }, { selector });
-    expect(false).to.deep.equal(value);
+    const selector = '.non-exist-child';
+    const value = getValue({ $, el }, { selector, methods: ['exist'] });
+
+    expect(value).to.deep.equal(false);
   });
 
   it('Case 18:  { [selector, selector], array with elementFilter }', () => {
@@ -275,7 +279,8 @@ describe('getValue Tests', () => {
       }
     };
     const value = getValue({ $, el }, config);
-    expect(['First Child']).to.deep.equal(value);
+
+    expect(value).to.deep.equal(['First Child']);
   });
 });
 

--- a/src/parser/getValue.spec.ts
+++ b/src/parser/getValue.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as cheerio from 'cheerio';
-import { RawConfig } from '../config/types';
+import { InputConfig, RawConfig } from '../config/types';
 import getValue from './getValue';
 
 const BLOCK_HTML = `
@@ -39,7 +39,7 @@ describe('getValue Tests', () => {
 
   it('Case 2:  { [selector, selector] }', () => {
     const el = '.parent';
-    const config: RawConfig = { selector: ['.first-child', '.second-child'] };
+    const config: RawConfig = { selector: '.first-child, .second-child' };
     const value = getValue({ $, el }, config);
     expect('First Child').to.deep.equal(value);
   });
@@ -47,7 +47,7 @@ describe('getValue Tests', () => {
   it('Case 3:  { [selector, selector], array }', () => {
     const el = $('.parent').first();
     const config: RawConfig = {
-      selector: ['.first-child', '.second-child'],
+      selector: '.first-child, .second-child',
       type: 'array'
     };
     const value = getValue({ $, el }, config);
@@ -268,7 +268,7 @@ describe('getValue Tests', () => {
   it('Case 18:  { [selector, selector], array with elementFilter }', () => {
     const el = $('.parent').first();
     const config: RawConfig = {
-      selector: ['.first-child', '.second-child'],
+      selector: '.first-child, .second-child',
       type: 'array',
       elementFilter: (index, el, $) => {
         return $(el).hasClass('first-child');
@@ -320,5 +320,16 @@ describe('ignoreExistenceChecks', () => {
     };
 
     expect(value).to.deep.equal(expected);
+  });
+});
+
+describe('MultipleSchemas', () => {
+  it('GetContentsOfTheFirstMatchingSelector', () => {
+    const conf: InputConfig = ['#non-existent', '.first-child'];
+    const el = $('.parent:first');
+    const val = getValue({ $, el }, conf);
+    const expected = $('.first-child:first').text();
+
+    expect(val).to.eq(expected);
   });
 });

--- a/src/parser/getValue.ts
+++ b/src/parser/getValue.ts
@@ -1,39 +1,21 @@
 import { ElementPassArg } from './types';
-import { Config } from '../config/types';
+import { RawConfig } from '../config/types';
 
-import getConfig from '../config/getConfig';
 import getElement from './getElement';
 import getSimpleValue from './getSimpleValue';
 import getSchemaValue from './getSchemaValue';
 import getArrayValue from './getArrayValue';
-import { getRawConfig } from './getRawConfig';
 
 function getValue<Initial = unknown>(
   { $, el }: ElementPassArg,
-  conf: Config<Initial>
+  config: RawConfig<Initial> | RawConfig<Initial>[]
 ) {
-  const rawConf = getRawConfig(conf);
-
-  if (Array.isArray(rawConf)) {
-    for (const conf of rawConf) {
-      const val = getValue({ $, el }, conf);
-
-      if (val !== null && val !== undefined) {
-        return val;
-      }
-    }
-
-    return null;
-  }
-
-  const config = getConfig({ $, el }, rawConf);
-
   if (Array.isArray(config)) {
     for (const conf of config) {
-      const val = getValue({ $, el }, conf);
+      const value = getValue({ $, el }, conf);
 
-      if (val !== null && val !== undefined) {
-        return val;
+      if (value !== null) {
+        return value;
       }
     }
 
@@ -54,7 +36,7 @@ function getValue<Initial = unknown>(
   }
 
   if (type === 'array') {
-    if (config?.methods?.includes('size')) {
+    if (config.methods?.includes('size')) {
       return $(element).length;
     }
 

--- a/src/parser/getValue.ts
+++ b/src/parser/getValue.ts
@@ -9,6 +9,19 @@ import getArrayValue from './getArrayValue';
 
 function getValue({ $, el }: ElementPassArg, inputConfig: InputConfig) {
   const config = getConfig({ $, el }, inputConfig);
+
+  if (Array.isArray(config)) {
+    for (const conf of config) {
+      const val = getValue({ $, el }, conf);
+
+      if (val !== null && val !== undefined) {
+        return val;
+      }
+    }
+
+    return null;
+  }
+
   const element = getElement({ $, el }, config);
   const { type, condition, exist, ...rest } = config;
   const { schema } = rest;

--- a/src/parser/getValue.ts
+++ b/src/parser/getValue.ts
@@ -56,13 +56,13 @@ function getValue<Initial = unknown>(
 
     return getArrayValue({ $, el: element }, rest);
   } else if (schema) {
-    let schm = schema;
+    let currentSchema = schema;
 
-    if (typeof schm === 'function') {
-      schm = schm($ && el ? $(el) : null);
+    if (typeof currentSchema === 'function') {
+      currentSchema = currentSchema($ && el ? $(el) : null);
     }
 
-    return getSchemaValue({ $, el: element }, schm);
+    return getSchemaValue({ $, el: element }, currentSchema);
   } else {
     return getSimpleValue({ $, el: element }, rest);
   }

--- a/src/parser/getValue.ts
+++ b/src/parser/getValue.ts
@@ -23,16 +23,30 @@ function getValue<Initial = unknown>(
   }
 
   const element = getElement({ $, el }, config);
-  const { type, condition, exist, ...rest } = config;
+  const { type, condition, exist, fill, ...rest } = config;
   const { schema } = rest;
   const elemExists = element.length > 0;
 
-  if (exist) {
+  if (exist || config.methods?.includes('exist')) {
     return elemExists;
   }
 
   if (condition && !condition($(el))) {
     return rest.initial ?? null;
+  }
+
+  if (fill) {
+    if (typeof fill === 'function') {
+      return fill();
+    }
+
+    return fill;
+  }
+
+  if (!elemExists) {
+    if (!(config.ignoreExistenceChecks === true)) {
+      return rest.initial ?? null;
+    }
   }
 
   if (type === 'array') {
@@ -42,12 +56,6 @@ function getValue<Initial = unknown>(
 
     return getArrayValue({ $, el: element }, rest);
   } else if (schema) {
-    if (!elemExists) {
-      if (!(config.ignoreExistenceChecks === true)) {
-        return rest.initial ?? null;
-      }
-    }
-
     let schm = schema;
 
     if (typeof schm === 'function') {

--- a/src/parser/parse.spec.ts
+++ b/src/parser/parse.spec.ts
@@ -62,7 +62,7 @@ describe('parse Tests', () => {
       }
     };
     const value = parse(data, config);
-    expect({
+    const expected = {
       unblock: [
         {
           title: 'Unblock',
@@ -73,6 +73,8 @@ describe('parse Tests', () => {
           description: 'Description'
         }
       ]
-    }).to.deep.equal(value);
+    };
+
+    expect(value).to.deep.equal(expected);
   });
 });

--- a/src/parser/parse.spec.ts
+++ b/src/parser/parse.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { InputConfig } from '../config/types';
+import { RawConfig } from '../config/types';
 import parse from './parse';
 
 const BLOCK_HTML = `
@@ -37,21 +37,21 @@ const SAMPLE_HTML = `
 describe('parse Tests', () => {
   it('Case 1:  { selector }', () => {
     const data = SAMPLE_HTML;
-    const config: InputConfig = { selector: '.first-child' };
+    const config: RawConfig = { selector: '.first-child' };
     const value = parse(data, config);
     expect('First Child').to.deep.equal(value);
   });
 
   it('Case 2:  { selector, array* }', () => {
     const data = SAMPLE_HTML;
-    const config: InputConfig = '.unblock div h4 | array';
+    const config: RawConfig = { selector: '.unblock div h4 | array' };
     const value = parse(data, config);
     expect(['Unblock', 'Unblock']).to.deep.equal(value);
   });
 
   it('Case 3:  { selector, array*, schema }', () => {
     const data = SAMPLE_HTML;
-    const config: InputConfig = {
+    const config: RawConfig = {
       selector: '.blocks @ href',
       schema: {
         unblock: {

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -1,4 +1,5 @@
 import { load, CheerioAPI } from 'cheerio';
+import parseSelector from '../config/parseSelector';
 import { Config } from '../config/types';
 import { getRawConfig } from './getRawConfig';
 import getValue from './getValue';

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -1,5 +1,6 @@
 import { load, CheerioAPI } from 'cheerio';
 import { Config } from '../config/types';
+import { getRawConfig } from './getRawConfig';
 import getValue from './getValue';
 
 function parse<Initial = unknown>(
@@ -14,7 +15,21 @@ function parse<Initial = unknown>(
     $ = data;
   }
 
-  return getValue({ $ }, config);
+  const rawConf = getRawConfig(config);
+
+  if (Array.isArray(rawConf)) {
+    for (const conf of rawConf) {
+      const value = getValue({ $, el: $ }, conf);
+
+      if (value !== null) {
+        return value;
+      }
+    }
+
+    return null;
+  }
+
+  return getValue({ $ }, rawConf);
 }
 
 export default parse;

--- a/src/parser/parse.ts
+++ b/src/parser/parse.ts
@@ -1,10 +1,10 @@
 import { load, CheerioAPI } from 'cheerio';
-import { InputConfig } from '../config/types';
+import { Config } from '../config/types';
 import getValue from './getValue';
 
-function parse(
+function parse<Initial = unknown>(
   data: string | CheerioAPI,
-  config: InputConfig
+  config: Config<Initial>
 ): Record<string, unknown> {
   let $;
 

--- a/src/parser/transformValue.spec.ts
+++ b/src/parser/transformValue.spec.ts
@@ -1,67 +1,66 @@
 import { expect } from 'chai';
-import getConfig from '../config/getConfig';
 
 import transformValue from './transformValue';
 
 describe('transformValue Tests', () => {
   it('Case 1: boolean - false', () => {
-    const config = { methods: ['boolean'] };
+    const config = { selector: '', methods: ['boolean'] };
     const value = '';
     const result = transformValue(value, config);
     expect(false).to.deep.equal(result);
   });
 
   it('Case 2: boolean - true', () => {
-    const config = { methods: ['boolean'] };
+    const config = { selector: '', methods: ['boolean'] };
     const value = 'Test';
     const result = transformValue(value, config);
     expect(true).to.deep.equal(result);
   });
 
   it('Case 3: number', () => {
-    const config = { methods: ['number'] };
+    const config = { selector: '', methods: ['number'] };
     const value = '12';
     const result = transformValue(value, config);
     expect(12).to.deep.equal(result);
   });
 
   it('Case 4: float', () => {
-    const config = { methods: ['float'] };
+    const config = { selector: '', methods: ['float'] };
     const value = '3.5';
     const result = transformValue(value, config);
     expect(3.5).to.deep.equal(result);
   });
 
   it('Case 5: trim', () => {
-    const config = getConfig({}, { methods: ['trim'] });
+    const config = { selector: '', methods: ['trim'] };
     const value = ' content ';
     const result = transformValue(value, config);
     expect('content').to.deep.equal(result);
   });
 
   it('Case 6: non-trim', () => {
-    const config = getConfig({}, { methods: ['non-trim'] });
+    const config = { selector: '', methods: ['non-trim'] };
     const value = ' content ';
     const result = transformValue(value, config);
     expect(' content ').to.deep.equal(result);
   });
 
   it('Case 7: lowercase', () => {
-    const config = getConfig({}, { methods: ['lowercase'] });
+    const config = { selector: '', methods: ['lowercase'] };
     const value = 'CONTENT';
     const result = transformValue(value, config);
     expect('content').to.deep.equal(result);
   });
 
   it('Case 8: uppercase', () => {
-    const config = getConfig({}, { methods: ['uppercase'] });
+    const config = { selector: '', methods: ['uppercase'] };
     const value = 'content';
     const result = transformValue(value, config);
     expect('CONTENT').to.deep.equal(result);
   });
 
   it('Case 9: length', () => {
-    const config = getConfig({}, { methods: ['length'] });
+    const config = { selector: '', methods: ['length'] };
     const value = 'content';
     const result = transformValue(value, config);
     expect(7).to.deep.equal(result);

--- a/src/parser/transformValue.spec.ts
+++ b/src/parser/transformValue.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { applyMethods } from '../config/applyMethods';
 
 import transformValue from './transformValue';
 
@@ -39,10 +40,11 @@ describe('transformValue Tests', () => {
   });
 
   it('Case 6: non-trim', () => {
-    const config = { selector: '', methods: ['non-trim'] };
+    const config = applyMethods({ selector: '', methods: ['non-trim'] });
     const value = ' content ';
     const result = transformValue(value, config);
-    expect(' content ').to.deep.equal(result);
+
+    expect(result).to.deep.equal(value);
   });
 
   it('Case 7: lowercase', () => {

--- a/src/parser/transformValue.ts
+++ b/src/parser/transformValue.ts
@@ -1,16 +1,20 @@
-import { Config } from '../config/types';
+import { RawConfig } from '../config/types';
 import Methods from './methods';
 import execRegex from './regex/execRegex';
+import { Value } from './value';
 
-function transformValue(value: any, config: Config) {
+function transformValue<Initial = unknown>(
+  value: Value<Initial>,
+  config: RawConfig<Initial>
+) {
   const { trim, regex, type, methods = [], transform } = config;
 
   if (typeof value === 'string' && trim !== false) {
     value = value.trim();
-  }
 
-  if (regex) {
-    value = execRegex(value, regex);
+    if (regex) {
+      value = execRegex(value, regex);
+    }
   }
 
   if (type) {

--- a/src/parser/value.ts
+++ b/src/parser/value.ts
@@ -1,0 +1,1 @@
+export type Value<Initial = unknown> = string | Initial;


### PR DESCRIPTION
Changes:
* The `InputConfig` removed.
* The `Config` `interface` converted to a `type` and replaced the `InputConfig`.
* `Selector` can only be `string` (was `string | string[]`)
* `transform` function takes `Value<Initial>` as argument, instead of `any`.
* `ConfigFunction` renamed to `SchemaGenerator`
* `RawConfig.schema`'s type is set to `SchemaGenerator | Schema`
* `getSelector` renamed to `parseSelector`