### PR TITLE
fix(parseSelector): handle empty selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muninn",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "It parses the html and collects the requested data as desired.",
   "main": "build/index.js",
   "scripts": {

--- a/src/config/parseSelector.spec.ts
+++ b/src/config/parseSelector.spec.ts
@@ -56,4 +56,37 @@ describe('parseSelector Tests', () => {
       methods: []
     }).to.deep.equal(value);
   });
+
+  it('only a method provided', () => {
+    const selector = '| uppercase';
+    const result = parseSelector(selector);
+    const expected = {
+      selector: '',
+      methods: ['uppercase']
+    };
+
+    expect(result).to.deep.eq(expected);
+  });
+
+  it('only two methods provided', () => {
+    const selector = '| uppercase | lowercase';
+    const result = parseSelector(selector);
+    const expected = {
+      selector: '',
+      methods: ['uppercase', 'lowercase']
+    };
+
+    expect(result).to.deep.eq(expected);
+  });
+
+  it('only an attribute provided', () => {
+    const selector = '@ href';
+    const result = parseSelector(selector);
+    const expected = {
+      selector: '',
+      attr: 'href'
+    };
+
+    expect(result).to.deep.eq(expected);
+  });
 });

--- a/src/config/parseSelector.ts
+++ b/src/config/parseSelector.ts
@@ -17,7 +17,7 @@ function parseSelector<Initial = unknown>(
     methods = methods.map((p: string) => p.trim());
   }
 
-  if (!$selector) {
+  if ($selector === undefined) {
     $selector = selector;
   }
 


### PR DESCRIPTION
parseSelector fails if an empty selector lefts from the `.split` operation.
for example, when we provide `| method` selector to the `parseSelector` method, after extracting methods an `$selector` becomes an empty selector and empty selectors are `falsy` values. so this if statement gets succeeded & executed:
```ts
if (!$selector) { // actually it's defined and a valid selector: "" (empty string)
  $selector = selector; // $selector will be set to "| method" here.
}
```
