### PR TITLE
Add multiple attribute support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muninn",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "It parses the html and collects the requested data as desired.",
   "main": "build/index.js",
   "scripts": {

--- a/src/config/parseSelector.spec.ts
+++ b/src/config/parseSelector.spec.ts
@@ -11,6 +11,22 @@ describe('parseSelector Tests', () => {
     expect(value).to.deep.equal(expected);
   });
 
+  it('Case 1.1: | @ multiple attrs', () => {
+    const selector = '@ href, rel';
+    const value = parseSelector(selector);
+    const expected = { selector: '', attr: ['href', 'rel'] };
+
+    expect(value).to.deep.equal(expected);
+  });
+
+  it('Case 1.2: @ all attrs', () => {
+    const selector = '@ $all';
+    const value = parseSelector(selector);
+    const expected = { selector: '', attr: '$all' };
+
+    expect(value).to.deep.equal(expected);
+  });
+
   it('Case 2: selector @ attr', () => {
     const selector = 'a.link @ href';
     const value = parseSelector(selector);

--- a/src/config/parseSelector.ts
+++ b/src/config/parseSelector.ts
@@ -5,7 +5,7 @@ function parseSelector<Initial = unknown>(
 ): RawConfig<Initial> {
   const config: RawConfig<Initial> = { selector: '' };
 
-  let $selector: string, methods: string[], attr: string;
+  let $selector: string, methods: string[], attr: string | string[];
 
   if (typeof selector !== 'string') {
     return selector;
@@ -23,6 +23,8 @@ function parseSelector<Initial = unknown>(
 
   if ($selector.includes('@')) {
     [$selector, attr] = $selector.split('@').map((key) => key.trim());
+    const attrs = attr.split(',').map((key) => key.trim());
+    attr = attrs.length > 1 ? attrs : attr;
   }
 
   if ($selector)

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -28,7 +28,7 @@ export type ConfigTypeValues = 'number' | 'float' | 'boolean' | 'array';
 export interface RawConfig<Initial = unknown> {
   selector?: Selector;
   html?: boolean;
-  attr?: string;
+  attr?: string | string[];
   type?: ConfigTypeValues;
   trim?: boolean;
   exist?: boolean;

--- a/src/parser/getSimpleValue.ts
+++ b/src/parser/getSimpleValue.ts
@@ -15,12 +15,21 @@ function getSimpleValue<Initial = unknown>(
   const { html, attr, initial } = config;
 
   const element = $(el);
-  let value: string | Initial;
+  let value: string | Record<string, string> | Initial;
 
   if (html) {
     value = element.html();
   } else if (attr) {
-    value = element.attr(attr);
+    if (Array.isArray(attr)) {
+      value = attr.reduce((acc, arg) => {
+        acc[arg] = element.attr(arg);
+        return acc;
+      }, {});
+    } else if (attr === '$all') {
+      value = element.attr();
+    } else {
+      value = element.attr(attr);
+    }
   } else {
     value = element.text();
   }

--- a/src/parser/getValue.spec.ts
+++ b/src/parser/getValue.spec.ts
@@ -16,7 +16,7 @@ const BLOCK_HTML = `
   <div class="trim-child"> Trim Content </div>
   <div class="html-child"><div class="content">Test</div></div>
   <div class="regex-template-test-child">https://example.com/ > example > test</div>
-  <a class="link" href="https://example.com/">Test Url</a>
+  <a class="link" href="https://example.com/" rel="noreferrer">Test Url</a>
 </div>
 `;
 
@@ -156,6 +156,24 @@ describe('getValue Tests', () => {
     const config = { selector: '.link', attr: 'href' };
     const value = getValue({ $ }, config);
     expect('https://example.com/').to.deep.equal(value);
+  });
+
+  it('Case 9.1:  { selector, mulitple attrs }', () => {
+    const config = { selector: '.link', attr: ['href', 'rel'] };
+    const value = getValue({ $ }, config);
+    expect({ href: 'https://example.com/', rel: 'noreferrer' }).to.deep.equal(
+      value
+    );
+  });
+
+  it('Case 9.2:  { selector, all attrs }', () => {
+    const config = { selector: '.link', attr: '$all' };
+    const value = getValue({ $ }, config);
+    expect({
+      href: 'https://example.com/',
+      rel: 'noreferrer',
+      class: 'link'
+    }).to.deep.equal(value);
   });
 
   it('Case 10: { selector, html }', () => {

--- a/src/parser/value.ts
+++ b/src/parser/value.ts
@@ -1,1 +1,4 @@
-export type Value<Initial = unknown> = string | Initial;
+export type Value<Initial = unknown> =
+  | string
+  | Record<string, string>
+  | Initial;


### PR DESCRIPTION
Multiple attributes or all of them can now be retrieved at once.

## Syntax:
### Multiple
`selector @ attr1, attr2, attr3`
### All
`selector @ $all`