### PR TITLE
feat: add `CheerioAPI` to `SchemaGenerator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 v0.15.0
 
+- Add `CheerioAPI` as second parameter to `SchemaGenerator`
+
+```ts
+schema: (el: Cheerio<Element>, $: CheerioAPI) => {};
+```
+
+v0.15.0
+
 - Remove unused `validateConfig` feature.
 - Update dependencies.
 - Update npmignore file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-v0.15.0
+v0.16.0
 
 - Add `CheerioAPI` as second parameter to `SchemaGenerator`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muninn",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "It parses the html and collects the requested data as desired.",
   "main": "build/index.js",
   "scripts": {

--- a/src/config/getConfig.ts
+++ b/src/config/getConfig.ts
@@ -24,7 +24,7 @@ function getConfig<Initial = unknown>(
   }
 
   if (typeof conf === 'function') {
-    const schema = conf($ && el ? $(el) : null);
+    const schema = conf($ && el ? $(el) : null, $);
 
     conf = {
       selector: '',

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -15,7 +15,8 @@ export interface Schema<Initial = unknown> {
   [key: string]: Config<Initial>;
 }
 export type SchemaGenerator<Initial = unknown> = (
-  el: Cheerio<Element>
+  el: Cheerio<Element>,
+  $: CheerioAPI
 ) => Schema<Initial>;
 export type ElementFilterFunction = (
   index: number,

--- a/src/parser/getValue.ts
+++ b/src/parser/getValue.ts
@@ -59,7 +59,7 @@ function getValue<Initial = unknown>(
     let currentSchema = schema;
 
     if (typeof currentSchema === 'function') {
-      currentSchema = currentSchema($ && el ? $(el) : null);
+      currentSchema = currentSchema($ && el ? $(el) : null, $);
     }
 
     return getSchemaValue({ $, el: element }, currentSchema);


### PR DESCRIPTION
- Add `CheerioAPI` as second parameter to `SchemaGenerator`

```ts
schema: (el: Cheerio<Element>, $: CheerioAPI) => {};
```