### PR TITLE
fix: value types that fill accepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+v0.19.0
+
+- The `fill` property now accepts falsy values other than `undefined`.
+```ts
+{ fill: null }
+{ fill: false }
+{ fill: "" }
+```
+
 v0.18.0
 
 - Add `element` parameter to `transform`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muninn",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "It parses the html and collects the requested data as desired.",
   "main": "build/index.js",
   "scripts": {

--- a/src/parser/getValue.spec.ts
+++ b/src/parser/getValue.spec.ts
@@ -221,6 +221,33 @@ describe('getValue Tests', () => {
     expect('link censored').to.deep.equal(value);
   });
 
+  it('Case 13: { selector, fill }', () => {
+    const config = {
+      selector: 'a.href',
+      fill: null
+    };
+    const value = getValue({ $ }, config);
+    expect(null).to.deep.equal(value);
+  });
+
+  it('Case 13: { selector, fill }', () => {
+    const config = {
+      selector: 'a.href',
+      fill: undefined
+    };
+    const value = getValue({ $ }, config);
+    expect(null).to.deep.equal(value);
+  });
+
+  it('Case 13: { selector, fill }', () => {
+    const config = {
+      selector: 'a.href',
+      fill: false
+    };
+    const value = getValue({ $ }, config);
+    expect(false).to.deep.equal(value);
+  });
+
   it('Case 13: { selector, fill() }', () => {
     const config: RawConfig = {
       selector: 'a.href',

--- a/src/parser/getValue.ts
+++ b/src/parser/getValue.ts
@@ -35,7 +35,7 @@ function getValue<Initial = unknown>(
     return rest.initial ?? null;
   }
 
-  if (fill) {
+  if (typeof fill !== 'undefined') {
     if (typeof fill === 'function') {
       return fill();
     }


### PR DESCRIPTION

- The `fill` property now accepts falsy values other than `undefined`.
```ts
{ fill: null }
{ fill: false }
{ fill: "" }
```